### PR TITLE
Use quote ID for adding items to cart.

### DIFF
--- a/src/Client.php
+++ b/src/Client.php
@@ -252,7 +252,7 @@ class Client
      */
     public function addProductToCart(int $quoteId, string $sku, int $quantity)
     {
-        return $this->request('post', $this->baseUrl . $this->apiPrefix . 'carts/mine/items', [
+        return $this->request('post', $this->baseUrl . $this->apiPrefix . 'carts/' . $quoteId . '/items', [
             'json' => [
                 'cartItem' => [
                     'sku' => $sku,


### PR DESCRIPTION
I think you should be using the carts/:quoteId/items endpoint, because this client doesn't use the Customer bearer token, but the admin token. This format is also used for the other endpoints (eg `$this->baseUrl . $this->apiPrefix . 'carts/' . $quoteId . '/shipping-information',`)
Format is the same: https://adobe-commerce.redoc.ly/2.4.6-admin/tag/cartsquoteIditems#operation/PostV1CartsQuoteIdItems